### PR TITLE
Add cwd option to .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
+  "cwd": ".",
   "directory": "bower_components",
   "analytics": false
 }


### PR DESCRIPTION
Bower now looks for .bowerrc files in all parent folders up to root. If it finds one, it might break the bower install command unless the working directory is explicitly set as this one.
