### PR TITLE
Stop using phantom for testing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,12 +4,9 @@ machine:
     version: 6.1.0
 dependencies:
   cache_directories:
-    - node_modules
     - bower_components
-  pre:
-    - npm i -g bower
   override:
-    - npm i
-    - bower i
+    - npm install
+    - bower install
   post:
     - npm rebuild node-sass

--- a/testem.json
+++ b/testem.json
@@ -3,10 +3,12 @@
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome",
+    "Firefox"
   ],
   "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
+    "Chrome",
+    "Firefox",
+    "Safari"
   ]
 }


### PR DESCRIPTION
Changed the test execution to use chrome and firefox on circleci. There are tests failing but they were already failing.