### PR TITLE
Prevent support button from covering content at the bottom of the page

### DIFF
--- a/app/styles/layout/_page-body.scss
+++ b/app/styles/layout/_page-body.scss
@@ -51,8 +51,8 @@
 
   @media (min-width: $breakpoint-desktop) {
     padding: $desktop-gutter;
+    padding-bottom: $desktop-gutter + 58px; // 58px is the height of the Zendesk support button
     overflow-x: visible;
-    min-height: none;
   }
 }
 


### PR DESCRIPTION
Also, min-height: none is invalid so I took it out. Shouldn't change anything.