### PR TITLE
use 100% width on sidebar-page__content

### DIFF
--- a/app/styles/layout/_page-body.scss
+++ b/app/styles/layout/_page-body.scss
@@ -40,7 +40,7 @@
 .sidebar-page__content {
   transition: all 0.25s ease-in-out;
   flex: 1;
-  max-width: calc(100vw - 220px);
+  max-width: 100%;
 }
 
 .page-content {


### PR DESCRIPTION
#### UX Review

- [ ] Functionality requirements
- [ ] Aesthetics
- [ ] Integrity

#### Regression Review

- [ ] Regression checked

This is intended to make use of the extra width gained by collapsing the sidebar. Currently you don't get any extra width unless the page is overflowing.

I can't find any side effects from this.
