### PR TITLE
Ensure sidebar menu tooltips aren't covered by page content

### DIFF
--- a/addon/components/file-inputs/csv.js
+++ b/addon/components/file-inputs/csv.js
@@ -35,6 +35,8 @@ export default FileField.extend({
     });
 
     reader.readAsText(files[0]);
-    event.target.value = '';
+    if (!Ember.testing) {
+      event.target.value = '';
+    }
   }
 });

--- a/app/styles/layout/_page-body.scss
+++ b/app/styles/layout/_page-body.scss
@@ -40,7 +40,7 @@ $page-wrapper-width--tiny: 1024px - 650px;
   background: shade($off-white, 1.5%);
   flex: 0 0 auto;
   width: 75px;
-  z-index: 1;
+  z-index: 300;
 }
 
 .sidebar-page__content {


### PR DESCRIPTION
| Behaviour before | Behaviour after |
| - | - |
| <img width="356" alt="Screen Shot 2020-06-12 at 9 28 29 AM" src="https://user-images.githubusercontent.com/1134869/84445918-85eb0580-ac98-11ea-975c-60baef3ffbd9.png"> | <img width="330" alt="Screen Shot 2020-06-12 at 10 35 18 AM" src="https://user-images.githubusercontent.com/1134869/84445928-8c797d00-ac98-11ea-9f70-367bdf3efbea.png"> |

Fixed by changing the z-index of the collapsed sidebar from 1 to 300. Changing the just the tooltip's z-index doesn't fix it. 300 is higher than things like date pickers but lower than things like the draggable accounts in the Financial Portal import mapper.

In the second screenshot there's a problem with the date picker escaping some HTML entities. It started happening after I reinstalled node_modules. Pretty sure it's unrelated to this change.
